### PR TITLE
Add package selection handler (triggered by CTA)

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -285,6 +285,7 @@ struct LoadedOfferingPaywallView: View {
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
+            .preference(key: SelectedPackagePreferenceKey.self, value: self.purchaseHandler.selectedPackage)
     }
 
     @ViewBuilder

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -285,7 +285,8 @@ struct LoadedOfferingPaywallView: View {
                         value: .init(data: self.purchaseHandler.purchaseResult))
             .preference(key: RestoredCustomerInfoPreferenceKey.self,
                         value: self.purchaseHandler.restoredCustomerInfo)
-            .preference(key: SelectedPackagePreferenceKey.self, value: self.purchaseHandler.selectedPackage)
+            .preference(key: InitiatedPurchaseWithSelectedPackagePreferenceKey.self,
+                        value: self.purchaseHandler.selectedPackage)
     }
 
     @ViewBuilder

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -42,6 +42,9 @@ final class PurchaseHandler: ObservableObject {
     /// When `restored` becomes `true`, this will include the `CustomerInfo` associated to it.
     @Published
     fileprivate(set) var restoredCustomerInfo: CustomerInfo?
+    
+    @Published
+    var selectedPackage: Package?
 
     private var eventData: PaywallEvent.Data?
 
@@ -77,6 +80,7 @@ extension PurchaseHandler {
         }
         defer { self.actionInProgress = false }
 
+        self.selectedPackage = package
         let result = try await self.purchases.purchase(package: package)
 
         if result.userCancelled {
@@ -236,6 +240,18 @@ struct RestoredCustomerInfoPreferenceKey: PreferenceKey {
     }
 
 }
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct SelectedPackagePreferenceKey: PreferenceKey {
+
+    static var defaultValue: Package?
+
+    static func reduce(value: inout Package?, nextValue: () -> Package?) {
+        value = nextValue()
+    }
+
+}
+
 
 // MARK: -
 

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -242,7 +242,7 @@ struct RestoredCustomerInfoPreferenceKey: PreferenceKey {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct SelectedPackagePreferenceKey: PreferenceKey {
+struct InitiatedPurchaseWithSelectedPackagePreferenceKey: PreferenceKey {
 
     static var defaultValue: Package?
 

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -76,9 +76,9 @@ public class PaywallViewController: UIViewController {
                 guard let self = self else { return }
                 self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
             }
-            .onSelectPackage { [weak self] package in
+            .onPurchaseInitiated { [weak self] selectedPackage in
                 guard let self = self else { return }
-                self.delegate?.paywallViewController?(self, didSelectPackage: package)
+                self.delegate?.paywallViewController?(self, didInitiatePurchaseWithSelectedPackage: selectedPackage)
             }
 
         return .init(rootView: view)
@@ -149,7 +149,7 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     /// Notifies that a purchase has been initiated in a ``PaywallViewController``.
     @objc(paywallViewController:didSelectPackage:)
     optional func paywallViewController(_ controller: PaywallViewController,
-                                        didSelectPackage package: Package)
+                                        didInitiatePurchaseWithSelectedPackage package: Package)
 }
 
 #endif

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -76,6 +76,10 @@ public class PaywallViewController: UIViewController {
                 guard let self = self else { return }
                 self.delegate?.paywallViewController?(self, didChangeSizeTo: $0)
             }
+            .onSelectPackage { [weak self] package in
+                guard let self = self else { return }
+                self.delegate?.paywallViewController?(self, didSelectPackage: package)
+            }
 
         return .init(rootView: view)
     }()
@@ -141,7 +145,11 @@ public protocol PaywallViewControllerDelegate: AnyObject {
     @objc(paywallViewControlle:didChangeSizeTo:)
     optional func paywallViewController(_ controller: PaywallViewController,
                                         didChangeSizeTo size: CGSize)
-
+    
+    /// Notifies that a purchase has been initiated in a ``PaywallViewController``.
+    @objc(paywallViewController:didSelectPackage:)
+    optional func paywallViewController(_ controller: PaywallViewController,
+                                        didSelectPackage package: Package)
 }
 
 #endif

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -21,7 +21,7 @@ public typealias PurchaseOrRestoreCompletedHandler = @MainActor @Sendable (Custo
 public typealias PurchaseCompletedHandler = @MainActor @Sendable (_ transaction: StoreTransaction?,
                                                                   _ customerInfo: CustomerInfo) -> Void
 
-public typealias PackageSelectedHandler = @MainActor @Sendable (_ package: Package) -> Void
+public typealias PurchaseInitiationHandler = @MainActor @Sendable (_ selectedPackage: Package) -> Void
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
@@ -112,11 +112,29 @@ extension View {
     ) -> some View {
         return self.modifier(OnRestoreCompletedModifier(handler: handler))
     }
-
-    public func onSelectPackage(
-        _ handler: @escaping PackageSelectedHandler
+    
+    /// Invokes the given closure when the CTA button is clicked.
+    /// The closure includes the `Package` that has been selected.
+    /// Example:
+    /// ```swift
+    ///  @State
+    ///  private var displayPaywall: Bool = true
+    ///
+    ///  var body: some View {
+    ///     ContentView()
+    ///         .sheet(isPresented: self.$displayPaywall) {
+    ///             PaywallView()
+    ///                 .onPurchaseInitiated { selectedPackage in
+    ///                     print("Purchase initiated with selected package: \(selectedPackage)")
+    ///                     self.displayPaywall = false
+    ///                 }
+    ///         }
+    ///  }
+    /// ```
+    public func onPurchaseInitiated(
+        _ handler: @escaping PurchaseInitiationHandler
     ) -> some View {
-        return self.modifier(OnPackageSelectedModifier(handler: handler))
+        return self.modifier(OnPurchaseInitiatedModifier(handler: handler))
     }
 }
 
@@ -161,13 +179,13 @@ private struct OnRestoreCompletedModifier: ViewModifier {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct OnPackageSelectedModifier: ViewModifier {
+private struct OnPurchaseInitiatedModifier: ViewModifier {
 
-    let handler: PackageSelectedHandler
+    let handler: PurchaseInitiationHandler
 
     func body(content: Content) -> some View {
         content
-            .onPreferenceChange(SelectedPackagePreferenceKey.self) { package in
+            .onPreferenceChange(InitiatedPurchaseWithSelectedPackagePreferenceKey.self) { package in
                 if let package {
                     self.handler(package)
                 }

--- a/RevenueCatUI/View+PurchaseRestoreCompleted.swift
+++ b/RevenueCatUI/View+PurchaseRestoreCompleted.swift
@@ -21,6 +21,8 @@ public typealias PurchaseOrRestoreCompletedHandler = @MainActor @Sendable (Custo
 public typealias PurchaseCompletedHandler = @MainActor @Sendable (_ transaction: StoreTransaction?,
                                                                   _ customerInfo: CustomerInfo) -> Void
 
+public typealias PackageSelectedHandler = @MainActor @Sendable (_ package: Package) -> Void
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 @available(macOS, unavailable, message: "RevenueCatUI does not support macOS yet")
 extension View {
@@ -111,6 +113,11 @@ extension View {
         return self.modifier(OnRestoreCompletedModifier(handler: handler))
     }
 
+    public func onSelectPackage(
+        _ handler: @escaping PackageSelectedHandler
+    ) -> some View {
+        return self.modifier(OnPackageSelectedModifier(handler: handler))
+    }
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
@@ -151,4 +158,19 @@ private struct OnRestoreCompletedModifier: ViewModifier {
             }
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private struct OnPackageSelectedModifier: ViewModifier {
+
+    let handler: PackageSelectedHandler
+
+    func body(content: Content) -> some View {
+        content
+            .onPreferenceChange(SelectedPackagePreferenceKey.self) { package in
+                if let package {
+                    self.handler(package)
+                }
+            }
+    }
 }


### PR DESCRIPTION
# What has changed

Added a purchase initiation handler, that is triggered when the user clicks on the CTA button.

The external logic can now be handled by the `paywallViewController(_:didInitiatePurchaseWithSelectedPackage:)` delegate method.