### PR TITLE
LIN-1451: add refresh subscriptions within RC

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -57,7 +57,7 @@ public struct PaywallView: View {
     public init(
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
-        refreshSubscriptions: @escaping () async throws -> Void
+        purchaseHandler: PurchaseHandler
     ) {
         self.init(
             offering: nil,
@@ -65,8 +65,7 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             introEligibility: nil,
-            purchaseHandler: nil,
-            refreshSubscriptions: refreshSubscriptions
+            purchaseHandler: purchaseHandler
         )
     }
 
@@ -84,7 +83,7 @@ public struct PaywallView: View {
         offering: Offering,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
-        refreshSubscriptions: @escaping () async throws -> Void
+        purchaseHandler: PurchaseHandler
     ) {
         self.init(
             offering: offering,
@@ -92,8 +91,7 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             introEligibility: nil,
-            purchaseHandler: nil,
-            refreshSubscriptions: refreshSubscriptions
+            purchaseHandler: purchaseHandler
         )
     }
 
@@ -104,13 +102,10 @@ public struct PaywallView: View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker?,
-        purchaseHandler: PurchaseHandler?,
-        refreshSubscriptions: @escaping () async throws -> Void
+        purchaseHandler: PurchaseHandler
     ) {
         self._introEligibility = .init(wrappedValue: introEligibility ?? .default())
-        let installedPurchaseHandler = purchaseHandler ?? .default()
-        installedPurchaseHandler.refreshSubscriptions = refreshSubscriptions
-        self._purchaseHandler = .init(wrappedValue: installedPurchaseHandler)
+        self._purchaseHandler = .init(wrappedValue: purchaseHandler)
         self._offering = .init(
             initialValue: offering ?? Self.loadCachedCurrentOfferingIfPossible()
         )
@@ -394,8 +389,7 @@ struct PaywallView_Previews: PreviewProvider {
                     customerInfo: TestData.customerInfo,
                     mode: mode,
                     introEligibility: PreviewHelpers.introEligibilityChecker,
-                    purchaseHandler: nil, 
-                    refreshSubscriptions: {}
+                    purchaseHandler: PurchaseHandler()
                 )
                 .previewLayout(mode.layout)
                 .previewDisplayName("\(offering.paywall?.templateName ?? "")-\(mode)")

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -389,7 +389,7 @@ struct PaywallView_Previews: PreviewProvider {
                     customerInfo: TestData.customerInfo,
                     mode: mode,
                     introEligibility: PreviewHelpers.introEligibilityChecker,
-                    purchaseHandler: PurchaseHandler()
+                    purchaseHandler: PreviewHelpers.purchaseHandler
                 )
                 .previewLayout(mode.layout)
                 .previewDisplayName("\(offering.paywall?.templateName ?? "")-\(mode)")

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -56,7 +56,8 @@ public struct PaywallView: View {
     /// If you want to handle that, you can use ``init(offering:)`` instead.
     public init(
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
-        displayCloseButton: Bool = false
+        displayCloseButton: Bool = false,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) {
         self.init(
             offering: nil,
@@ -64,7 +65,8 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             introEligibility: nil,
-            purchaseHandler: nil
+            purchaseHandler: nil,
+            refreshSubscriptions: refreshSubscriptions
         )
     }
 
@@ -81,7 +83,8 @@ public struct PaywallView: View {
     public init(
         offering: Offering,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
-        displayCloseButton: Bool = false
+        displayCloseButton: Bool = false,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) {
         self.init(
             offering: offering,
@@ -89,7 +92,8 @@ public struct PaywallView: View {
             fonts: fonts,
             displayCloseButton: displayCloseButton,
             introEligibility: nil,
-            purchaseHandler: nil
+            purchaseHandler: nil,
+            refreshSubscriptions: refreshSubscriptions
         )
     }
 
@@ -100,10 +104,13 @@ public struct PaywallView: View {
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         displayCloseButton: Bool = false,
         introEligibility: TrialOrIntroEligibilityChecker?,
-        purchaseHandler: PurchaseHandler?
+        purchaseHandler: PurchaseHandler?,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) {
         self._introEligibility = .init(wrappedValue: introEligibility ?? .default())
-        self._purchaseHandler = .init(wrappedValue: purchaseHandler ?? .default())
+        let installedPurchaseHandler = purchaseHandler ?? .default()
+        installedPurchaseHandler.refreshSubscriptions = refreshSubscriptions
+        self._purchaseHandler = .init(wrappedValue: installedPurchaseHandler)
         self._offering = .init(
             initialValue: offering ?? Self.loadCachedCurrentOfferingIfPossible()
         )
@@ -387,7 +394,8 @@ struct PaywallView_Previews: PreviewProvider {
                     customerInfo: TestData.customerInfo,
                     mode: mode,
                     introEligibility: PreviewHelpers.introEligibilityChecker,
-                    purchaseHandler: PreviewHelpers.purchaseHandler
+                    purchaseHandler: nil, 
+                    refreshSubscriptions: {}
                 )
                 .previewLayout(mode.layout)
                 .previewDisplayName("\(offering.paywall?.templateName ?? "")-\(mode)")

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -16,7 +16,7 @@ import StoreKit
 import SwiftUI
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-final class PurchaseHandler: ObservableObject {
+public final class PurchaseHandler: ObservableObject {
 
     private let purchases: PaywallPurchasesType
 
@@ -44,6 +44,8 @@ final class PurchaseHandler: ObservableObject {
     fileprivate(set) var restoredCustomerInfo: CustomerInfo?
 
     private var eventData: PaywallEvent.Data?
+    
+    var refreshSubscriptions: () async throws -> Void = {}
 
     convenience init(purchases: Purchases = .shared) {
         self.init(isConfigured: true, purchases: purchases)
@@ -78,6 +80,7 @@ extension PurchaseHandler {
         defer { self.actionInProgress = false }
 
         let result = try await self.purchases.purchase(package: package)
+        try await refreshSubscriptions()
 
         if result.userCancelled {
             self.trackCancelledPurchase()
@@ -99,6 +102,7 @@ extension PurchaseHandler {
         defer { self.actionInProgress = false }
 
         let customerInfo = try await self.purchases.restorePurchases()
+        try await refreshSubscriptions()
 
         withAnimation(Constants.defaultAnimation) {
             self.restored = true

--- a/RevenueCatUI/Purchasing/PurchaseHandler.swift
+++ b/RevenueCatUI/Purchasing/PurchaseHandler.swift
@@ -45,7 +45,7 @@ public final class PurchaseHandler: ObservableObject {
 
     private var eventData: PaywallEvent.Data?
     
-    var refreshSubscriptions: () async throws -> Void = {}
+    public var refreshSubscriptions: () async throws -> Void = {}
 
     convenience init(purchases: Purchases = .shared) {
         self.init(isConfigured: true, purchases: purchases)

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -34,17 +34,28 @@ public final class PaywallFooterViewController: PaywallViewController {
     /// Initialize a `PaywallFooterViewController` with an optional `Offering`.
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// `Offerings.current` will be used by default.
-    @objc
-    public init(offering: Offering? = nil) {
-        super.init(offering: offering, displayCloseButton: false)
+    public init(
+        offering: Offering? = nil,
+        refreshSubscriptions: @escaping () async throws -> Void
+    ) {
+        super.init(
+            offering: offering,
+            displayCloseButton: false,
+            refreshSubscriptions: refreshSubscriptions
+        )
     }
 
     @available(*, unavailable)
     override init(
         offering: Offering? = nil,
-        displayCloseButton: Bool = false
+        displayCloseButton: Bool = false,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) {
-        super.init(offering: offering, displayCloseButton: false)
+        super.init(
+            offering: offering,
+            displayCloseButton: false,
+            refreshSubscriptions: refreshSubscriptions
+        )
     }
 
     // swiftlint:disable:next missing_docs

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -57,13 +57,14 @@ public class PaywallViewController: UIViewController {
     }
 
     private lazy var hostingController: UIHostingController<some View> = {
+        let purchaseHandler = PurchaseHandler()
+        purchaseHandler.refreshSubscriptions = refreshSubscriptions
         let view = PaywallView(offering: self.offering,
                                customerInfo: nil,
                                mode: self.mode,
                                displayCloseButton: self.displayCloseButton,
                                introEligibility: nil,
-                               purchaseHandler: nil,
-                               refreshSubscriptions: refreshSubscriptions)
+                               purchaseHandler: purchaseHandler)
             .onPurchaseCompleted { [weak self] transaction, customerInfo in
                 guard let self = self else { return }
                 self.delegate?.paywallViewController?(self, didFinishPurchasingWith: customerInfo)

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -33,18 +33,20 @@ public class PaywallViewController: UIViewController {
 
     private let offering: Offering?
     private let displayCloseButton: Bool
+    private let refreshSubscriptions: () async throws -> Void
 
     /// Initialize a `PaywallViewController` with an optional `Offering`.
     /// - Parameter offering: The `Offering` containing the desired `PaywallData` to display.
     /// `Offerings.current` will be used by default.
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
-    @objc
     public init(
         offering: Offering? = nil,
-        displayCloseButton: Bool = false
+        displayCloseButton: Bool = false,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) {
         self.offering = offering
         self.displayCloseButton = displayCloseButton
+        self.refreshSubscriptions = refreshSubscriptions
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -60,7 +62,8 @@ public class PaywallViewController: UIViewController {
                                mode: self.mode,
                                displayCloseButton: self.displayCloseButton,
                                introEligibility: nil,
-                               purchaseHandler: nil)
+                               purchaseHandler: nil,
+                               refreshSubscriptions: refreshSubscriptions)
             .onPurchaseCompleted { [weak self] transaction, customerInfo in
                 guard let self = self else { return }
                 self.delegate?.paywallViewController?(self, didFinishPurchasingWith: customerInfo)

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -33,7 +33,8 @@ extension View {
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) -> some View {
         return self.paywallFooter(
             offering: nil,
@@ -42,7 +43,8 @@ extension View {
             fonts: fonts,
             introEligibility: nil,
             purchaseCompleted: purchaseCompleted,
-            restoreCompleted: restoreCompleted
+            restoreCompleted: restoreCompleted,
+            refreshSubscriptions: refreshSubscriptions
         )
     }
 
@@ -61,7 +63,8 @@ extension View {
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) -> some View {
         return self.paywallFooter(
             offering: offering,
@@ -70,7 +73,8 @@ extension View {
             fonts: fonts,
             introEligibility: nil,
             purchaseCompleted: purchaseCompleted,
-            restoreCompleted: restoreCompleted
+            restoreCompleted: restoreCompleted,
+            refreshSubscriptions: refreshSubscriptions
         )
     }
 
@@ -82,7 +86,8 @@ extension View {
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
         purchaseHandler: PurchaseHandler? = nil,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
+        refreshSubscriptions: @escaping () async throws -> Void
     ) -> some View {
         return self
             .modifier(PresentingPaywallFooterModifier(
@@ -93,7 +98,8 @@ extension View {
                 restoreCompleted: restoreCompleted,
                 fontProvider: fonts,
                 introEligibility: introEligibility,
-                purchaseHandler: purchaseHandler
+                purchaseHandler: purchaseHandler,
+                refreshSubscriptions: refreshSubscriptions
             ))
     }
 }
@@ -110,6 +116,7 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
     let fontProvider: PaywallFontProvider
     let introEligibility: TrialOrIntroEligibilityChecker?
     let purchaseHandler: PurchaseHandler?
+    let refreshSubscriptions: () async throws -> Void
 
     func body(content: Content) -> some View {
         content
@@ -120,7 +127,8 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
                     mode: self.condensed ? .condensedFooter : .footer,
                     fonts: self.fontProvider,
                     introEligibility: self.introEligibility,
-                    purchaseHandler: self.purchaseHandler
+                    purchaseHandler: self.purchaseHandler,
+                    refreshSubscriptions: self.refreshSubscriptions
                 )
                 .onPurchaseCompleted {
                     self.purchaseCompleted?($0)

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -32,19 +32,19 @@ extension View {
     public func paywallFooter(
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        purchaseHandler: PurchaseHandler,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        refreshSubscriptions: @escaping () async throws -> Void
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
     ) -> some View {
         return self.paywallFooter(
             offering: nil,
             customerInfo: nil,
             condensed: condensed,
             fonts: fonts,
-            introEligibility: nil,
+            introEligibility: nil, 
+            purchaseHandler: purchaseHandler,
             purchaseCompleted: purchaseCompleted,
-            restoreCompleted: restoreCompleted,
-            refreshSubscriptions: refreshSubscriptions
+            restoreCompleted: restoreCompleted
         )
     }
 
@@ -62,9 +62,9 @@ extension View {
         offering: Offering,
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
+        purchaseHandler: PurchaseHandler,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        refreshSubscriptions: @escaping () async throws -> Void
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
     ) -> some View {
         return self.paywallFooter(
             offering: offering,
@@ -72,9 +72,9 @@ extension View {
             condensed: condensed,
             fonts: fonts,
             introEligibility: nil,
+            purchaseHandler: purchaseHandler,
             purchaseCompleted: purchaseCompleted,
-            restoreCompleted: restoreCompleted,
-            refreshSubscriptions: refreshSubscriptions
+            restoreCompleted: restoreCompleted
         )
     }
 
@@ -84,10 +84,9 @@ extension View {
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         introEligibility: TrialOrIntroEligibilityChecker? = nil,
-        purchaseHandler: PurchaseHandler? = nil,
+        purchaseHandler: PurchaseHandler,
         purchaseCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil,
-        refreshSubscriptions: @escaping () async throws -> Void
+        restoreCompleted: PurchaseOrRestoreCompletedHandler? = nil
     ) -> some View {
         return self
             .modifier(PresentingPaywallFooterModifier(
@@ -98,8 +97,7 @@ extension View {
                 restoreCompleted: restoreCompleted,
                 fontProvider: fonts,
                 introEligibility: introEligibility,
-                purchaseHandler: purchaseHandler,
-                refreshSubscriptions: refreshSubscriptions
+                purchaseHandler: purchaseHandler
             ))
     }
 }
@@ -115,8 +113,7 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
     let restoreCompleted: PurchaseOrRestoreCompletedHandler?
     let fontProvider: PaywallFontProvider
     let introEligibility: TrialOrIntroEligibilityChecker?
-    let purchaseHandler: PurchaseHandler?
-    let refreshSubscriptions: () async throws -> Void
+    let purchaseHandler: PurchaseHandler
 
     func body(content: Content) -> some View {
         content
@@ -127,8 +124,7 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
                     mode: self.condensed ? .condensedFooter : .footer,
                     fonts: self.fontProvider,
                     introEligibility: self.introEligibility,
-                    purchaseHandler: self.purchaseHandler,
-                    refreshSubscriptions: self.refreshSubscriptions
+                    purchaseHandler: self.purchaseHandler
                 )
                 .onPurchaseCompleted {
                     self.purchaseCompleted?($0)


### PR DESCRIPTION
Add `refreshSubscriptions` to `PurchaseHandler`. Called from 'purchase' and 'restore'.
I've spend some time trying to add it to Purchases.swift, but that is much more involved. 
There are 9(!) methods to make purchase, and some other for restore.

Progress is directly displayed and so is the error in case 'refreshSubscription' fails.
Well, it's not localized:
<img width="678" alt="Screenshot 2024-01-18 at 11 25 17 AM" src="https://github.com/LinearityGmbH/purchases-ios/assets/575303/2b18406b-9efd-48da-b500-1651daabfd87">

but that's a different problem