### PR TITLE
LIN-1516: fix tappable area

### DIFF
--- a/RevenueCatUI/Views/PurchaseButton.swift
+++ b/RevenueCatUI/Views/PurchaseButton.swift
@@ -86,6 +86,9 @@ struct PurchaseButton: View {
             #if !os(watchOS)
             .padding()
             #endif
+            #if targetEnvironment(macCatalyst)
+            .contentShape(Rectangle())
+            #endif
             .hidden(if: !self.isEnabled)
             .overlay {
                 if !self.isEnabled {


### PR DESCRIPTION
Adjust tappable area for purchase button in MacOS. Tried out adjusting frames and etc, but for `style == .plain` [this seems the solution](https://sarunw.com/posts/swiftui-button-cannot-tap/)

[Jira ticket here](https://vectornator.atlassian.net/browse/LIN-1516)