### PR TITLE
LIN-1571: Add paywall offering selection

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -142,7 +142,11 @@ public struct PaywallView: View {
         var initialOffering: Offering?
         if let offering {
             initialOffering = offering
-        } else if offeringSelection == nil {
+        } else if let offeringSelection,
+                  Purchases.isConfigured,
+                  let cachedOfferings = Purchases.shared.cachedOfferings {
+            initialOffering = offeringSelection(cachedOfferings)
+        } else {
             initialOffering = Self.loadCachedCurrentOfferingIfPossible()
         }
         self._offering = .init(initialValue: initialOffering)

--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -142,10 +142,10 @@ public struct PaywallView: View {
         var initialOffering: Offering?
         if let offering {
             initialOffering = offering
-        } else if let offeringSelection,
-                  Purchases.isConfigured,
-                  let cachedOfferings = Purchases.shared.cachedOfferings {
-            initialOffering = offeringSelection(cachedOfferings)
+        } else if let offeringSelection {
+            if Purchases.isConfigured, let cachedOfferings = Purchases.shared.cachedOfferings {
+                initialOffering = offeringSelection(cachedOfferings)
+            }
         } else {
             initialOffering = Self.loadCachedCurrentOfferingIfPossible()
         }

--- a/RevenueCatUI/UIKit/PaywallFooterViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallFooterViewController.swift
@@ -48,11 +48,13 @@ public final class PaywallFooterViewController: PaywallViewController {
     @available(*, unavailable)
     override init(
         offering: Offering? = nil,
+        offeringSelection: ((Offerings) -> Offering?)? = nil,
         displayCloseButton: Bool = false,
         refreshSubscriptions: @escaping () async throws -> Void
     ) {
         super.init(
             offering: offering,
+            offeringSelection: offeringSelection,
             displayCloseButton: false,
             refreshSubscriptions: refreshSubscriptions
         )

--- a/RevenueCatUI/UIKit/PaywallViewController.swift
+++ b/RevenueCatUI/UIKit/PaywallViewController.swift
@@ -32,6 +32,7 @@ public class PaywallViewController: UIViewController {
     }
 
     private let offering: Offering?
+    private let offeringSelection: ((Offerings) -> Offering?)?
     private let displayCloseButton: Bool
     private let refreshSubscriptions: () async throws -> Void
 
@@ -41,10 +42,12 @@ public class PaywallViewController: UIViewController {
     /// - Parameter displayCloseButton: Set this to `true` to automatically include a close button.
     public init(
         offering: Offering? = nil,
+        offeringSelection: ((Offerings) -> Offering?)? = nil,
         displayCloseButton: Bool = false,
         refreshSubscriptions: @escaping () async throws -> Void
     ) {
         self.offering = offering
+        self.offeringSelection = offeringSelection
         self.displayCloseButton = displayCloseButton
         self.refreshSubscriptions = refreshSubscriptions
 
@@ -60,6 +63,7 @@ public class PaywallViewController: UIViewController {
         let purchaseHandler = PurchaseHandler()
         purchaseHandler.refreshSubscriptions = refreshSubscriptions
         let view = PaywallView(offering: self.offering,
+                               offeringSelection: self.offeringSelection,
                                customerInfo: nil,
                                mode: self.mode,
                                displayCloseButton: self.displayCloseButton,

--- a/RevenueCatUI/View+PresentPaywall.swift
+++ b/RevenueCatUI/View+PresentPaywall.swift
@@ -163,6 +163,7 @@ private struct PresentingPaywallModifier: ViewModifier {
     var onDismiss: (() -> Void)?
 
     var offering: Offering?
+    var offeringSelection: ((Offerings) -> Offering?)?
     var fontProvider: PaywallFontProvider
 
     var customerInfoFetcher: View.CustomerInfoFetcher
@@ -177,6 +178,7 @@ private struct PresentingPaywallModifier: ViewModifier {
             .sheet(item: self.$data, onDismiss: self.onDismiss) { data in
                 PaywallView(
                     offering: self.offering,
+                    offeringSelection: self.offeringSelection,
                     customerInfo: data.customerInfo,
                     fonts: self.fontProvider,
                     displayCloseButton: true,

--- a/RevenueCatUI/View+PresentPaywallFooter.swift
+++ b/RevenueCatUI/View+PresentPaywallFooter.swift
@@ -60,6 +60,7 @@ extension View {
     /// [Documentation](https://rev.cat/paywalls)
     public func paywallFooter(
         offering: Offering,
+        offeringSelection: ((Offerings) -> Offering?)? = nil,
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
         purchaseHandler: PurchaseHandler,
@@ -68,6 +69,7 @@ extension View {
     ) -> some View {
         return self.paywallFooter(
             offering: offering,
+            offeringSelection: offeringSelection,
             customerInfo: nil,
             condensed: condensed,
             fonts: fonts,
@@ -80,6 +82,7 @@ extension View {
 
     func paywallFooter(
         offering: Offering?,
+        offeringSelection: ((Offerings) -> Offering?)? = nil,
         customerInfo: CustomerInfo?,
         condensed: Bool = false,
         fonts: PaywallFontProvider = DefaultPaywallFontProvider(),
@@ -91,6 +94,7 @@ extension View {
         return self
             .modifier(PresentingPaywallFooterModifier(
                 offering: offering,
+                offeringSelection: offeringSelection,
                 customerInfo: customerInfo,
                 condensed: condensed,
                 purchaseCompleted: purchaseCompleted,
@@ -106,6 +110,7 @@ extension View {
 private struct PresentingPaywallFooterModifier: ViewModifier {
 
     let offering: Offering?
+    let offeringSelection: ((Offerings) -> Offering?)?
     let customerInfo: CustomerInfo?
     let condensed: Bool
 
@@ -120,6 +125,7 @@ private struct PresentingPaywallFooterModifier: ViewModifier {
             .safeAreaInset(edge: .bottom) {
                 PaywallView(
                     offering: self.offering,
+                    offeringSelection: self.offeringSelection,
                     customerInfo: self.customerInfo,
                     mode: self.condensed ? .condensedFooter : .footer,
                     fonts: self.fontProvider,

--- a/Tests/RevenueCatUITests/BaseSnapshotTest.swift
+++ b/Tests/RevenueCatUITests/BaseSnapshotTest.swift
@@ -61,6 +61,7 @@ class BaseSnapshotTest: TestCase {
         purchaseHandler: PurchaseHandler = BaseSnapshotTest.purchaseHandler
     ) -> some View {
         return PaywallView(offering: offering,
+                           offeringSelection: nil,
                            customerInfo: TestData.customerInfo,
                            mode: mode,
                            fonts: fonts,

--- a/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
+++ b/Tests/RevenueCatUITests/PaywallViewEventsTests.swift
@@ -138,6 +138,7 @@ private extension PaywallViewEventsTests {
     func createView() -> some View {
         PaywallView(
             offering: Self.offering.withLocalImages,
+            offeringSelection: nil,
             customerInfo: TestData.customerInfo,
             mode: self.mode,
             introEligibility: .producing(eligibility: .eligible),

--- a/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
+++ b/Tests/RevenueCatUITests/PurchaseCompletedHandlerTests.swift
@@ -31,6 +31,7 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         try PaywallView(
             offering: Self.offering.withLocalImages,
+            offeringSelection: nil,
             customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: handler
@@ -54,6 +55,7 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         try PaywallView(
             offering: Self.offering.withLocalImages,
+            offeringSelection: nil,
             customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
@@ -75,6 +77,7 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         try PaywallView(
             offering: Self.offering.withLocalImages,
+            offeringSelection: nil,
             customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler
@@ -98,6 +101,7 @@ class PurchaseCompletedHandlerTests: TestCase {
 
         try PaywallView(
             offering: Self.offering.withLocalImages,
+            offeringSelection: nil,
             customerInfo: TestData.customerInfo,
             introEligibility: .producing(eligibility: .eligible),
             purchaseHandler: Self.purchaseHandler


### PR DESCRIPTION
# What has changed

Added a possibility to select a specific offering when presenting a paywall.

# How to use it

Initialize the `PaywallViewController` providing an `offeringSelection` parameter, and return the specific offering that you would like to present. Returning `nil` from the closure will fall back to displaying the default offering.

```swift
let paywallViewController = PaywallViewController(
            offeringSelection: { offerings in
                // return the selected offering or nil
            },
            refreshSubscriptions: premiumFeatureProvider.refreshSubscriptions
        )
```