### PR TITLE
NOTICKET: fix cell transition

### DIFF
--- a/RevenueCatUI/Templates/LinTemplate5View.swift
+++ b/RevenueCatUI/Templates/LinTemplate5View.swift
@@ -262,15 +262,10 @@ struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View
                         self.roundedRectangle.fill(
                             selected
                             ? Color(
-                                light: Color(
-                                    red: 0xFF / 255.0, green: 0xF8 / 255.0, blue: 0xF3 / 255.0
-                                ),
-                                dark: Color(
-                                    red: 0xFF / 255.0,
-                                    green: 0x96 / 255.0,
-                                    blue: 0x14 / 255.0,
-                                    opacity: 0x0D / 255.0
-                                )
+                                red: 0xFF / 255.0,
+                                green: 0x96 / 255.0,
+                                blue: 0x14 / 255.0,
+                                opacity: 0x0D / 255.0
                             )
                             : .clear
                         )


### PR DESCRIPTION
https://linearity.slack.com/archives/C066SV8CFNZ/p1716277269291829 see thread.
So the problem is that we switch .clearColor -> Linearity/Cream (close to white), 
that causes 0,0,0,0 -> 255,255,255,1 transition
which involves a grey color.


So use the color with alpha for selected