### PR TITLE
NOTICKET: tune paddings

### DIFF
--- a/RevenueCatUI/Modifiers/ViewExtensions.swift
+++ b/RevenueCatUI/Modifiers/ViewExtensions.swift
@@ -169,7 +169,7 @@ extension View {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct DefaultHorizontalPaddingModifier: ViewModifier {
+struct DefaultHorizontalPaddingModifier: ViewModifier {
 
     @Environment(\.userInterfaceIdiom)
     private var interfaceIdiom
@@ -182,7 +182,7 @@ private struct DefaultHorizontalPaddingModifier: ViewModifier {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-private struct DefaultVerticalPaddingModifier: ViewModifier {
+struct DefaultVerticalPaddingModifier: ViewModifier {
 
     @Environment(\.userInterfaceIdiom)
     private var interfaceIdiom
@@ -192,6 +192,13 @@ private struct DefaultVerticalPaddingModifier: ViewModifier {
             .padding(.vertical, Constants.defaultVerticalPaddingLength(self.interfaceIdiom))
     }
 
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct NoPaddingModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+    }
 }
 
 // MARK: - scrollableIfNecessary

--- a/RevenueCatUI/Templates/LinTemplate4View.swift
+++ b/RevenueCatUI/Templates/LinTemplate4View.swift
@@ -63,7 +63,7 @@ struct LinTemplate4View: TemplateViewType {
             HStack(spacing: 0) {
                 paywallContent(displayTimeline: false)
                     .padding(EdgeInsets(top: 0, leading: 32, bottom: 0, trailing: 32))
-                AuxiliaryDetailsView(eligible: eligible).frame(width: 335)
+                AuxiliaryDetailsView(eligible: eligible).frame(maxWidth: 335)
             }
         default:
             paywallContent(displayTimeline: eligible)

--- a/RevenueCatUI/Templates/LinTemplate4View.swift
+++ b/RevenueCatUI/Templates/LinTemplate4View.swift
@@ -41,7 +41,8 @@ struct LinTemplate4View: TemplateViewType {
                 ? localize("Title.EligibleOffering", value: "Try Linearity Pro for free")
                 : localize("Title.NonEligibleOffering", value: "Upgrade to Linearity Pro")
             },
-            getDefaultContentWidth: Constants.defaultContentWidth
+            getDefaultContentWidth: Constants.defaultContentWidth,
+            horizontalPaddingModifier: NoPaddingModifier()
         ) {
             if displayTimeline {
                 TimelineView(stepConfigurations: TimelineView.defaultIPhone, axis: .horizontal)
@@ -53,7 +54,7 @@ struct LinTemplate4View: TemplateViewType {
                 textWithIntroOffer: msgProvider.makeTextWithIntroOffer(selectedPackage),
                 introEligibility: eligibility
             )
-        }
+        }.font(.footnote)
     }
     
     var body: some View {
@@ -61,10 +62,12 @@ struct LinTemplate4View: TemplateViewType {
         case .regular:
             HStack(spacing: 0) {
                 paywallContent(displayTimeline: false)
-                AuxiliaryDetailsView(eligible: eligible)
+                    .padding(EdgeInsets(top: 0, leading: 32, bottom: 0, trailing: 32))
+                AuxiliaryDetailsView(eligible: eligible).frame(width: 335)
             }
         default:
             paywallContent(displayTimeline: eligible)
+                .padding(EdgeInsets(top: 0, leading: 24, bottom: 0, trailing: 24))
         }
     }
     

--- a/RevenueCatUI/Templates/LinTemplate5View.swift
+++ b/RevenueCatUI/Templates/LinTemplate5View.swift
@@ -37,7 +37,8 @@ struct LinTemplate5View: TemplateViewType {
             selectedPackage: $selectedPackage,
             displayImage: true,
             titleProvider: { package in package.localization.title },
-            getDefaultContentWidth: Constants.defaultContentWidth,
+            getDefaultContentWidth: Constants.defaultContentWidth, 
+            horizontalPaddingModifier: DefaultHorizontalPaddingModifier(),
             subtitleBuilder: { EmptyView() },
             buttonSubtitleBuilder: { (_, _ , _) in EmptyView() }
         )
@@ -45,7 +46,7 @@ struct LinTemplate5View: TemplateViewType {
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
-struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View>: View {
+struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View, HorizontalPadding: ViewModifier>: View {
     typealias SubtitleBuilder = () -> SubtitleView
     typealias ButtonSubtitleBuilder = (
             _ selectedPackage: Package,
@@ -83,6 +84,7 @@ struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View
     private let subtitleBuilder: SubtitleBuilder
     private let getDefaultContentWidth: (UserInterfaceIdiom) -> CGFloat?
     private let titleProvider: (TemplateViewConfiguration.Package) -> String
+    private let horizontalPaddingModifier: HorizontalPadding
 
     init(
         _ configuration: TemplateViewConfiguration,
@@ -90,6 +92,7 @@ struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View
         displayImage: Bool,
         titleProvider: @escaping (TemplateViewConfiguration.Package) -> String,
         getDefaultContentWidth: @escaping (UserInterfaceIdiom) -> CGFloat?,
+        horizontalPaddingModifier: HorizontalPadding,
         @ViewBuilder subtitleBuilder: @escaping SubtitleBuilder,
         @ViewBuilder buttonSubtitleBuilder: @escaping ButtonSubtitleBuilder
     ) {
@@ -100,6 +103,7 @@ struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View
         self.buttonSubtitleBuilder = buttonSubtitleBuilder
         self.getDefaultContentWidth = getDefaultContentWidth
         self.titleProvider = titleProvider
+        self.horizontalPaddingModifier = horizontalPaddingModifier
         self._displayingAllPlans = .init(initialValue: configuration.mode.displayAllPlansByDefault)
     }
     
@@ -122,7 +126,7 @@ struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View
 
             self.subscribeButton
                 .frame(maxWidth: defaultContentWidth)
-                .defaultHorizontalPadding()
+                .modifier(horizontalPaddingModifier)
             
             buttonSubtitleBuilder(
                 selectedPackage.content,
@@ -188,7 +192,7 @@ struct LinConfigurableTemplate5View<SubtitleView: View, ButtonSubtitleView: View
                 }
             }
             .frame(maxWidth: self.defaultContentWidth)
-            .defaultHorizontalPadding()
+            .modifier(horizontalPaddingModifier)
         }
         .frame(maxHeight: .infinity)
     }


### PR DESCRIPTION
Some UI tweaks for the new paywall:

this is random & outdated screenshot that I have:
<img width="449" alt="Screenshot 2024-05-14 at 12 42 37 PM" src="https://github.com/LinearityGmbH/purchases-ios/assets/575303/0eef77a6-7ad9-4dd0-82f8-cc76abdaf425">
