### PR TITLE
LIN-2201: Dynamic trial period

### DIFF
--- a/RevenueCatUI/Data/TemplateViewConfiguration.swift
+++ b/RevenueCatUI/Data/TemplateViewConfiguration.swift
@@ -57,6 +57,14 @@ extension TemplateViewConfiguration {
         case single(Package)
         case multiple(first: Package, default: Package, all: [Package])
 
+        var introductoryOfferDaysDuration: Int? {
+            switch self {
+            case .single(let package):
+                package.content.introductoryOfferDaysDuration
+            case .multiple(_, _, let all):
+                all.first(where: { $0.content.introductoryOfferDaysDuration != nil })?.content.introductoryOfferDaysDuration
+            }
+        }
     }
 
 }

--- a/RevenueCatUI/Templates/LinTemplate4View.swift
+++ b/RevenueCatUI/Templates/LinTemplate4View.swift
@@ -45,7 +45,7 @@ struct LinTemplate4View: TemplateViewType {
             horizontalPaddingModifier: NoPaddingModifier()
         ) {
             if displayTimeline {
-                TimelineView(stepConfigurations: TimelineView.defaultIPhone, axis: .horizontal)
+                TimelineView(stepConfigurations: TimelineView.defaultIPhone(introductoryOfferDaysDuration: configuration.packages.introductoryOfferDaysDuration), axis: .horizontal)
             }
         } buttonSubtitleBuilder: { selectedPackage, eligibility, locale in
             let msgProvider = CTAFooterMessageProvider(locale: locale)
@@ -63,7 +63,7 @@ struct LinTemplate4View: TemplateViewType {
             HStack(spacing: 0) {
                 paywallContent(displayTimeline: false)
                     .padding(EdgeInsets(top: 0, leading: 32, bottom: 6, trailing: 32))
-                AuxiliaryDetailsView(eligible: eligible).frame(maxWidth: 335)
+                auxiliaryDetailsView(eligible: eligible).frame(maxWidth: 335)
             }
         default:
             paywallContent(displayTimeline: eligible)
@@ -75,28 +75,26 @@ struct LinTemplate4View: TemplateViewType {
         introEligibilityViewModel.allEligibility[selectedPackage.content] == .eligible
     }
     
-    private struct AuxiliaryDetailsView: View {
-        let eligible: Bool
-        var body: some View {
+    @ViewBuilder
+    func auxiliaryDetailsView(eligible: Bool) -> some View {
+        VStack(alignment: .leading) {
             VStack(alignment: .leading) {
-                VStack(alignment: .leading) {
-                    Spacer()
-                    if eligible {
-                        TimelineView(stepConfigurations: TimelineView.defaultIPad, axis: .vertical)
-                        Spacer().frame(height: 60)
-                    }
-                    TestimonialsView()
-                    Spacer()
+                Spacer()
+                if eligible {
+                    TimelineView(stepConfigurations: TimelineView.defaultIPad(introductoryOfferDaysDuration: configuration.packages.introductoryOfferDaysDuration), axis: .vertical)
+                    Spacer().frame(height: 60)
                 }
-                CompanyLogosView()
-                Spacer().frame(height: 18)
+                TestimonialsView()
+                Spacer()
             }
-            .padding([.leading, .trailing], 40)
-            .background(Color(
-                light: Color(red: 242 / 255.0, green: 242 / 255.0, blue: 242 / 255.0),
-                dark: Color(red: 44 / 255.0, green: 44 / 255.0, blue: 46 / 255.0)
-            ))
+            CompanyLogosView()
+            Spacer().frame(height: 18)
         }
+        .padding([.leading, .trailing], 40)
+        .background(Color(
+            light: Color(red: 242 / 255.0, green: 242 / 255.0, blue: 242 / 255.0),
+            dark: Color(red: 44 / 255.0, green: 44 / 255.0, blue: 46 / 255.0)
+        ))
     }
 }
 

--- a/RevenueCatUI/Views/TimelineView.swift
+++ b/RevenueCatUI/Views/TimelineView.swift
@@ -13,6 +13,7 @@ import RevenueCat
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 struct TimelineView: View {
+    static let defaultIntroductoryOfferDaysDuration = 7
     static var bundle = Foundation.Bundle.module
     
     enum Colors {
@@ -217,9 +218,11 @@ private func localize(_ key: String, value: String) -> String {
 @available(tvOS, unavailable)
 extension TimelineView {
     
-    static var defaultIPad: [StepConfiguration] {[
-        StepConfiguration(
-            title: localize("iPad.step1.title", value: "Today: Free trial for 7 days"),
+    static func defaultIPad(introductoryOfferDaysDuration: Int? = nil) -> [StepConfiguration] {
+        let introductoryOfferDaysDuration = introductoryOfferDaysDuration ?? Self.defaultIntroductoryOfferDaysDuration
+        return [
+            StepConfiguration(
+            title: String(format:localize("iPad.step1.title", value: "Today: Free trial for 7 days"), introductoryOfferDaysDuration),
             icon: "gift",
             iconBackgroundColor: TimelineView.Colors.green,
             iconForegroundColor: .black,
@@ -228,7 +231,7 @@ extension TimelineView {
             linkPosition: .trailing
         ),
         StepConfiguration(
-            title: localize("iPad.step2.title", value: "Day 5: Reminder"),
+            title: String(format: localize("iPad.step2.title", value: "Day 5: Reminder"), introductoryOfferDaysDuration - 2),
             icon: "bell",
             iconForegroundColor: TimelineView.Colors.bell,
             subtitle: localize(
@@ -239,7 +242,7 @@ extension TimelineView {
             linkPosition: .both
         ),
         StepConfiguration(
-            title: localize("iPad.step3.title", value: "Day 7: Trial ends"),
+            title: String(format: localize("iPad.step3.title", value: "Day 7: Trial ends"), introductoryOfferDaysDuration),
             icon: "crown.fill",
             iconForegroundColor: TimelineView.Colors.linearityOrange,
             subtitle: localize(
@@ -251,32 +254,34 @@ extension TimelineView {
         )
     ]}
     
-    static var defaultIPhone: [StepConfiguration] {[
-        StepConfiguration(
-            title: localize("iPhone.step1.title", value: "Start free trial"),
-            icon: "gift",
-            iconBackgroundColor: TimelineView.Colors.green,
-            iconForegroundColor: .black,
-            subtitle: localize("iPhone.step1.subtitle", value: "Today"),
-            linkColor: TimelineView.Colors.green,
-            linkPosition: .trailing
-        ),
-        StepConfiguration(
-            title: localize("iPhone.step2.title", value: "Reminder"),
-            icon: "bell",
-            subtitle: localize("iPhone.step2.subtitle", value: "Day 5"),
-            linkColor: TimelineView.Colors.link,
-            linkPosition: .both
-        ),
-        StepConfiguration(
-            title: localize("iPhone.step3.title", value: "Trial ends"),
-            icon: "crown.fill",
-            iconForegroundColor: TimelineView.Colors.linearityOrange,
-            subtitle: localize("iPhone.step3.subtitle", value: "Day 7"),
-            linkColor: TimelineView.Colors.link,
-            linkPosition: .leading
-        )
-    ]}
+    static func defaultIPhone(introductoryOfferDaysDuration: Int? = nil) -> [StepConfiguration] {
+        let introductoryOfferDaysDuration = introductoryOfferDaysDuration ?? Self.defaultIntroductoryOfferDaysDuration
+        return [
+            StepConfiguration(
+                title: localize("iPhone.step1.title", value: "Start free trial"),
+                icon: "gift",
+                iconBackgroundColor: TimelineView.Colors.green,
+                iconForegroundColor: .black,
+                subtitle: localize("iPhone.step1.subtitle", value: "Today"),
+                linkColor: TimelineView.Colors.green,
+                linkPosition: .trailing
+            ),
+            StepConfiguration(
+                title: localize("iPhone.step2.title", value: "Reminder"),
+                icon: "bell",
+                subtitle: String(format: localize("iPhone.step2.subtitle", value: "Day 5"), introductoryOfferDaysDuration - 2),
+                linkColor: TimelineView.Colors.link,
+                linkPosition: .both
+            ),
+            StepConfiguration(
+                title: localize("iPhone.step3.title", value: "Trial ends"),
+                icon: "crown.fill",
+                iconForegroundColor: TimelineView.Colors.linearityOrange,
+                subtitle: String(format: localize("iPhone.step3.subtitle", value: "Day 7"), introductoryOfferDaysDuration),
+                linkColor: TimelineView.Colors.link,
+                linkPosition: .leading
+            )
+        ]}
 }
 
 private extension NSLayoutConstraint.Axis {
@@ -309,14 +314,14 @@ private extension HorizontalAlignment {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         TimelineView(
-            stepConfigurations: TimelineView.defaultIPhone,
+            stepConfigurations: TimelineView.defaultIPhone(),
             axis: .horizontal
         )
         .previewDevice(PreviewDevice(rawValue: "iPhone 15 Pro"))
         .previewDisplayName("iPhone")
         
         TimelineView(
-            stepConfigurations: TimelineView.defaultIPad,
+            stepConfigurations: TimelineView.defaultIPad(),
             axis: .vertical
         )
         .previewDevice(PreviewDevice(rawValue: "iPad Pro 11-inch (M4)"))

--- a/Sources/Purchasing/Package.swift
+++ b/Sources/Purchasing/Package.swift
@@ -100,6 +100,23 @@ import Foundation
     @objc public let packageType: PackageType
     /// The underlying ``storeProduct``
     @objc public let storeProduct: StoreProduct
+    
+    public var introductoryOfferDaysDuration: Int? {
+        guard let subscriptionPeriod = storeProduct.introductoryDiscount?.subscriptionPeriod else {
+            return nil
+        }
+        switch subscriptionPeriod.unit {
+        case .day:
+            return subscriptionPeriod.value
+        case .week:
+            return subscriptionPeriod.value * 7
+        case .month:
+            // Best effort, not really supported
+            return subscriptionPeriod.value * 30
+        case .year:
+            return subscriptionPeriod.value * 365
+        }
+    }
 
     ////  The information about the ``Offering`` containing this Package
     @objc public let presentedOfferingContext: PresentedOfferingContext


### PR DESCRIPTION
The following changes introduce a new API to be able to have a dynamic trial period: 7 days, 14 days... 
It comes with some limitations: 
- if you set a month of free trial then you might have a difference of 1 day
- Does not support having multiple product with trial period but this could be improved in the future