### PR TITLE
LIN-2194: Add new lin paywall template selection

### DIFF
--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -132,6 +132,12 @@ extension PaywallData {
             )
         }
     }
+    
+    enum LinPaywall: Int {
+        case defaultRC
+        case canvaStyleOneStep
+        case canvaStyleTwoSteps
+    }
 
     @ViewBuilder
     private static func createView(offering: Offering,
@@ -150,10 +156,17 @@ extension PaywallData {
         case .template4:
             Template4View(configuration)
         case .template5:
-            if offering.getMetadataValue(for: "show_new_paywall", default: false) {
-                LinTemplate4View(configuration)
-            } else {
+            // In case the offering was not updated yet, keep reading the previous selection value.
+            let oldSelectionFallback: LinPaywall = offering.getMetadataValue(for: "show_new_paywall", default: false) ? .canvaStyleOneStep : .defaultRC
+            let paywallVersion = LinPaywall(rawValue: offering.getMetadataValue(for: "paywall_version", default: oldSelectionFallback.rawValue)) ?? oldSelectionFallback
+            switch paywallVersion {
+            case .defaultRC:
                 LinTemplate5View(configuration)
+            case .canvaStyleOneStep:
+                LinTemplate4View(configuration)
+            case .canvaStyleTwoSteps:
+                // As it's not ready yet, we return the previous version
+                LinTemplate4View(configuration)
             }
         }
         #endif


### PR DESCRIPTION
[LIN-2194](https://vectornator.atlassian.net/browse/LIN-2194)

Add new template selection from offering metadata. To test it you can tap on the subscribe button in the menu and update [this offer](https://app.revenuecat.com/projects/cdf2de77/offerings/ofrng9a15feba08)

[LIN-2194]: https://vectornator.atlassian.net/browse/LIN-2194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ