### PR TITLE
LIN-2496: Override purchase button title

### DIFF
--- a/RevenueCatUI/Templates/LinTemplates/LinTemplateNavigationView.swift
+++ b/RevenueCatUI/Templates/LinTemplates/LinTemplateNavigationView.swift
@@ -74,7 +74,7 @@ struct LinTemplateNavigationView: TemplateViewType, IntroEligibilityProvider {
     @ViewBuilder
     var buttonTitle: some View {
         PurchaseButtonLabel(
-            package: configuration.packages.single,
+            packages: configuration.packages,
             colors: configuration.colors,
             introEligibility: introEligibility
         )


### PR DESCRIPTION
[LIN-2496](https://vectornator.atlassian.net/browse/LIN-2496)

Instead of taking the CTA from the web config, it's taken from the ressources.
On the step 1, it will show the longest trial period if multiple are available.

Also remove unused code



[LIN-2496]: https://vectornator.atlassian.net/browse/LIN-2496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ