### PR TITLE
LIN-2500: Add sync pending attributes before showing paywall

### DIFF
--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -416,6 +416,10 @@ extension Attribution {
     func unsyncedAttributesByKey(appUserID: String) -> SubscriberAttribute.Dictionary {
         self.subscriberAttributesManager.unsyncedAttributesByKey(appUserID: appUserID)
     }
+    
+    public var isThereUnsyncedAttributes: Bool {
+        !subscriberAttributesManager.unsyncedAttributesByKeyForAllUsers().isEmpty
+    }
 
     var unsyncedAdServicesToken: String? {
         get async {


### PR DESCRIPTION
Sync the latest attributes (if any) and offerings before showing the paywall