### PR TITLE
LIN-2518: Step1 Paywall Configuration

### DIFF
--- a/RevenueCatUI/Templates/LinTemplates/LinTemplateNavigationView.swift
+++ b/RevenueCatUI/Templates/LinTemplates/LinTemplateNavigationView.swift
@@ -13,6 +13,7 @@ import RevenueCat
 struct LinTemplateNavigationView: TemplateViewType, IntroEligibilityProvider {
     
     let configuration: TemplateViewConfiguration
+    let step1Configuration: LinTemplateStep1Configuration
     
     @Environment(\.userInterfaceIdiom)
     var userInterfaceIdiom
@@ -31,16 +32,19 @@ struct LinTemplateNavigationView: TemplateViewType, IntroEligibilityProvider {
     
     init(_ configuration: TemplateViewConfiguration) {
         self.configuration = configuration
+        self.step1Configuration = .default
         self.showAllPackages = true
         _hideCloseButton = Binding.constant(true)
     }
     
     init(
         _ configuration: TemplateViewConfiguration,
+        step1Configuration: LinTemplateStep1Configuration,
         showAllPackages: Bool,
         hideCloseButton: Binding<Bool>
     ) {
         self.configuration = configuration
+        self.step1Configuration = step1Configuration
         self.showAllPackages = showAllPackages
         _hideCloseButton = hideCloseButton
     }
@@ -49,6 +53,7 @@ struct LinTemplateNavigationView: TemplateViewType, IntroEligibilityProvider {
         NavigationStack {
             LinTemplateStep1View(
                 configuration: configuration,
+                auxiliaryConfiguration: step1Configuration,
                 accentColor: accentColor
             ) {
                 LinNavigationLink(
@@ -105,6 +110,7 @@ struct LinTemplateNavigation_Previews: PreviewProvider {
             ) {
                 LinTemplateNavigationView(
                     $0,
+                    step1Configuration: .default,
                     showAllPackages: false,
                     hideCloseButton: Binding.constant(true)
                 )

--- a/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
+++ b/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
@@ -9,10 +9,42 @@ import Foundation
 import RevenueCat
 import SwiftUI
 
+struct LinTemplateStep1Configuration: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case titleKey = "title_key"
+        case imageName = "image_name"
+    }
+    
+    let titleKey: String
+    let imageName: String
+}
+
+extension LinTemplateStep1Configuration {
+    static let `default` = LinTemplateStep1Configuration(
+        titleKey: "Step1.AuxiliaryDetailsView.Artboards",
+        imageName: "paywall-first-step-artboards"
+    )
+}
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+private extension LinTemplateStep1Configuration {
+    var title: String {
+        localize(titleKey, value: "Auxiliary Title")
+    }
+    
+    var image: ImageResource {
+        ImageResource(
+            name: imageName,
+            bundle: LinTemplatesResources.linTemplate5Step1Bundle
+        )
+    }
+}
+
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 struct LinTemplateStep1View<ButtonView: View>: View, IntroEligibilityProvider {
     
     let configuration: TemplateViewConfiguration
+    let auxiliaryConfiguration: LinTemplateStep1Configuration
     
     private let accentColor: Color
     private let buttonView: () -> ButtonView
@@ -36,10 +68,12 @@ struct LinTemplateStep1View<ButtonView: View>: View, IntroEligibilityProvider {
     
     init(
         configuration: TemplateViewConfiguration,
+        auxiliaryConfiguration: LinTemplateStep1Configuration,
         accentColor: Color,
         buttonView: @escaping () -> ButtonView
     ) {
         self.configuration = configuration
+        self.auxiliaryConfiguration = auxiliaryConfiguration
         self.accentColor = accentColor
         self.buttonView = buttonView
     }
@@ -123,20 +157,13 @@ struct LinTemplateStep1View<ButtonView: View>: View, IntroEligibilityProvider {
     
     @ViewBuilder
     private var auxiliaryDetailsView: some View {
-        #if targetEnvironment(macCatalyst)
-        let imageName = "paywall-first-step-macOS"
-        #else
-        let imageName = "paywall-first-step-iOS"
-        #endif
-        let imageResource = ImageResource(name: imageName, bundle: LinTemplatesResources.linTemplate5Step1Bundle)
         VStack() {
             Spacer()
-            // wrap around LocalizedStringKey to have Markdown support
-            Text(LocalizedStringKey(localize("Step1.AuxiliaryDetailsView.Title", value: "Boost your productivity **with AI-powered tools**")))
+            Text(LocalizedStringKey(auxiliaryConfiguration.title))
                 .font(.system(size: 20))
                 .foregroundStyle(.black)
                 .padding([.leading, .trailing, .bottom], 20)
-            Image(imageResource)
+            Image(auxiliaryConfiguration.image)
                 .resizable()
                 .aspectRatio(contentMode: .fit)
             Spacer()
@@ -173,6 +200,10 @@ struct LinTemplate5Step1View_Previews: PreviewProvider {
             ) { configuration in
                 LinTemplateStep1View(
                     configuration: configuration,
+                    auxiliaryConfiguration: .init(
+                        titleKey: "Hi **Paywall**",
+                        imageName: "paywall-first-step-macOS"
+                    ),
                     accentColor: configuration.colors.accent1Color
                 ) {
                     LinNavigationLink(

--- a/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
+++ b/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
@@ -15,21 +15,24 @@ struct LinTemplateStep1Configuration: Decodable {
         case imageName = "image_name"
     }
     
-    let titleKey: String
+    let titleKey: String?
     let imageName: String
 }
 
 extension LinTemplateStep1Configuration {
     static let `default` = LinTemplateStep1Configuration(
-        titleKey: "Step1.AuxiliaryDetailsView.Artboards",
-        imageName: "paywall-first-step-artboards"
+        titleKey: nil,
+        imageName: "paywall-first-step-general"
     )
 }
 
 @available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
 private extension LinTemplateStep1Configuration {
-    var title: String {
-        localize(titleKey, value: "Auxiliary Title")
+    var title: String? {
+        if let titleKey {
+            return localize(titleKey, value: "Auxiliary Title")
+        }
+        return nil
     }
     
     var image: ImageResource {
@@ -157,12 +160,14 @@ struct LinTemplateStep1View<ButtonView: View>: View, IntroEligibilityProvider {
     
     @ViewBuilder
     private var auxiliaryDetailsView: some View {
-        VStack() {
+        VStack {
             Spacer()
-            Text(LocalizedStringKey(auxiliaryConfiguration.title))
-                .font(.system(size: 20))
-                .foregroundStyle(.black)
-                .padding([.leading, .trailing, .bottom], 20)
+            if let title = auxiliaryConfiguration.title {
+                Text(LocalizedStringKey(title))
+                    .font(.system(size: 20))
+                    .foregroundStyle(.black)
+                    .padding([.leading, .trailing, .bottom], 20)
+            }
             Image(auxiliaryConfiguration.image)
                 .resizable()
                 .aspectRatio(contentMode: .fit)

--- a/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
+++ b/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
@@ -12,19 +12,22 @@ import SwiftUI
 struct LinTemplateStep1Configuration: Decodable {
     enum CodingKeys: String, CodingKey {
         case titleKey = "title_key"
-        case imageName = "image_name"
+        case imageNameMacOS = "image_name_macos"
+        case imageNameIOS = "image_name_ios"
         case backgroundColourName = "background_colour_name"
     }
     
     let titleKey: String?
-    let imageName: String
+    let imageNameMacOS: String
+    let imageNameIOS: String
     let backgroundColourName: String
 }
 
 extension LinTemplateStep1Configuration {
     static let `default` = LinTemplateStep1Configuration(
         titleKey: nil,
-        imageName: "paywall-first-step-general",
+        imageNameMacOS: "paywall-first-step-general",
+        imageNameIOS: "paywall-first-step-general",
         backgroundColourName: "paywall-first-step-general-colour"
     )
 }
@@ -39,7 +42,12 @@ private extension LinTemplateStep1Configuration {
     }
     
     var image: ImageResource {
-        ImageResource(
+        #if targetEnvironment(macCatalyst)
+        let imageName = imageNameMacOS
+        #else
+        let imageName = imageNameIOS
+        #endif
+        return ImageResource(
             name: imageName,
             bundle: LinTemplatesResources.linTemplate5Step1Bundle
         )
@@ -214,7 +222,8 @@ struct LinTemplate5Step1View_Previews: PreviewProvider {
                     configuration: configuration,
                     auxiliaryConfiguration: .init(
                         titleKey: "Hi **Paywall**",
-                        imageName: "paywall-first-step-macOS",
+                        imageNameMacOS: "paywall-first-step-macOS",
+                        imageNameIOS: "paywall-first-step-iOS",
                         backgroundColourName: "paywall-first-step-general-colour"
                     ),
                     accentColor: configuration.colors.accent1Color

--- a/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
+++ b/RevenueCatUI/Templates/LinTemplates/LinTemplateStep1View.swift
@@ -13,16 +13,19 @@ struct LinTemplateStep1Configuration: Decodable {
     enum CodingKeys: String, CodingKey {
         case titleKey = "title_key"
         case imageName = "image_name"
+        case backgroundColourName = "background_colour_name"
     }
     
     let titleKey: String?
     let imageName: String
+    let backgroundColourName: String
 }
 
 extension LinTemplateStep1Configuration {
     static let `default` = LinTemplateStep1Configuration(
         titleKey: nil,
-        imageName: "paywall-first-step-general"
+        imageName: "paywall-first-step-general",
+        backgroundColourName: "paywall-first-step-general-colour"
     )
 }
 
@@ -40,6 +43,10 @@ private extension LinTemplateStep1Configuration {
             name: imageName,
             bundle: LinTemplatesResources.linTemplate5Step1Bundle
         )
+    }
+    
+    var backgroundColour: Color {
+        Color(backgroundColourName, bundle: LinTemplatesResources.linTemplate5Step1Bundle)
     }
 }
 
@@ -173,7 +180,7 @@ struct LinTemplateStep1View<ButtonView: View>: View, IntroEligibilityProvider {
                 .aspectRatio(contentMode: .fit)
             Spacer()
         }
-        .background(Color("paywall-first-step-imageBackgroundColor", bundle: LinTemplatesResources.linTemplate5Step1Bundle))
+        .background(auxiliaryConfiguration.backgroundColour)
     }
 }
 
@@ -207,7 +214,8 @@ struct LinTemplate5Step1View_Previews: PreviewProvider {
                     configuration: configuration,
                     auxiliaryConfiguration: .init(
                         titleKey: "Hi **Paywall**",
-                        imageName: "paywall-first-step-macOS"
+                        imageName: "paywall-first-step-macOS",
+                        backgroundColourName: "paywall-first-step-general-colour"
                     ),
                     accentColor: configuration.colors.accent1Color
                 ) {

--- a/RevenueCatUI/Templates/TemplateViewType.swift
+++ b/RevenueCatUI/Templates/TemplateViewType.swift
@@ -148,6 +148,7 @@ extension PaywallData {
             // In case the offering was not updated yet, keep reading the previous selection value.
             let oldSelectionFallback: LinPaywall = offering.getMetadataValue(for: "show_new_paywall", default: false) ? .canvaStyleOneStep : .defaultRC
             let paywallVersion = LinPaywall(rawValue: offering.getMetadataValue(for: "paywall_version", default: oldSelectionFallback.rawValue)) ?? oldSelectionFallback
+            let step1Configuration: LinTemplateStep1Configuration = offering.getMetadataValue(for: "step1_paywall", default: .default)
             switch paywallVersion {
             case .defaultRC:
                 LinTemplateView(configuration)
@@ -155,7 +156,12 @@ extension PaywallData {
                 LinTemplateStep2View(configuration)
             case .canvaStyleTwoSteps:
                 if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
-                    LinTemplateNavigationView(configuration)
+                    LinTemplateNavigationView(
+                        configuration,
+                        step1Configuration: step1Configuration,
+                        showAllPackages: true,
+                        hideCloseButton: .constant(true)
+                    )
                 } else {
                     LinTemplateStep2View(configuration)
                 }
@@ -163,13 +169,23 @@ extension PaywallData {
                 LinTemplateStep2View(configuration, showBackButton: false, showAllPackages: false)
             case .canvaStyleTwoStepsMonthlyHidden:
                 if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
-                    LinTemplateNavigationView(configuration, showAllPackages: false, hideCloseButton: Binding.constant(true))
+                    LinTemplateNavigationView(
+                        configuration,
+                        step1Configuration: step1Configuration,
+                        showAllPackages: false,
+                        hideCloseButton: Binding.constant(true)
+                    )
                 } else {
                     LinTemplateStep2View(configuration, showBackButton: false, showAllPackages: false)
                 }
             case .canvaStyleTwoStepsMonthlyHiddenCloseHiddenOnFirstStep:
                 if #available(iOS 16.0, macOS 13.0, tvOS 16.0, *) {
-                    LinTemplateNavigationView(configuration, showAllPackages: false, hideCloseButton: hideCloseButton)
+                    LinTemplateNavigationView(
+                        configuration,
+                        step1Configuration: step1Configuration,
+                        showAllPackages: false,
+                        hideCloseButton: hideCloseButton
+                    )
                 } else {
                     LinTemplateStep2View(configuration, showBackButton: false, showAllPackages: false)
                 }


### PR DESCRIPTION
Added the ability to configure Step1 title, background colour, and image based on the Offering.metadata.

Proposed metadata structure:

<img width="372" alt="Screenshot 2024-10-17 at 15 24 38" src="https://github.com/user-attachments/assets/5bda75ce-05e0-48c0-8ba6-c337ecbfb372">

Ticket:
https://vectornator.atlassian.net/browse/LIN-2518