### PR TITLE
EX-2341: Fix DM close button color

### DIFF
--- a/RevenueCatUI/PaywallView.swift
+++ b/RevenueCatUI/PaywallView.swift
@@ -505,13 +505,8 @@ struct LoadedOfferingPaywallView: View {
                     Circle()
                         .fill(
                             Color(
-                                light: .white,
-                                dark: Color(
-                                    red: 118.0 / 255.0,
-                                    green: 118 / 255.0,
-                                    blue: 128 / 255.0,
-                                    opacity: 0.24
-                                )
+                                light: Color.white,
+                                dark: .black
                             )
                         )
                         .frame(width: 30)
@@ -520,13 +515,8 @@ struct LoadedOfferingPaywallView: View {
                         .font(.system(size: 12, weight: .medium))
                         .foregroundColor(
                             Color(
-                                light: .black,
-                                dark: Color(
-                                    red: 235.0 / 255.0,
-                                    green: 235.0 / 255.0,
-                                    blue: 245.0 / 255.0,
-                                    opacity: 0.6
-                                )
+                                light: Color.black,
+                                dark: .white
                             )
                         )
                 }


### PR DESCRIPTION
I fixed the close button being not really visible in DM.

Before
<img width="224" alt="Capture d’écran 2025-03-17 à 15 36 51" src="https://github.com/user-attachments/assets/bfeee282-c42c-4ae0-82ac-9176955c66dd" />

Now
<img width="224" alt="Capture d’écran 2025-03-17 à 15 36 24" src="https://github.com/user-attachments/assets/d8abba93-26fa-4910-ad00-e18697fcecf2" />

