### PR TITLE
EX-2829: Web payment

### DIFF
--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -24,6 +24,7 @@ struct ButtonComponentView: View {
     @State private var showCustomerCenter = false
     @State private var showingWebPaywallLinkAlert = false
     @State private var webPaywallLinkURL: URL?
+    @State private var linearityPaywallLinkURL: URL?
 
     @EnvironmentObject
     private var purchaseHandler: PurchaseHandler
@@ -85,6 +86,9 @@ struct ButtonComponentView: View {
                         }
 #endif
                         onDismiss()
+                    } else if let linearityPaywallLinkURL {
+                        navigateToUrl(url: linearityPaywallLinkURL, method: .externalBrowser)
+                        onDismiss()
                     }
                 }
             } message: {
@@ -142,7 +146,7 @@ struct ButtonComponentView: View {
         case .url(let url, let method),
                 .privacyPolicy(let url, let method),
                 .terms(let url, let method):
-            navigateToUrl(url: url, method: method)
+            openLinearityPaywallLink(url: url)
         case .unknown:
             break
         case .webPaywallLink(url: let url, method: let method):
@@ -195,6 +199,11 @@ struct ButtonComponentView: View {
         case .unknown:
             break
         }
+    }
+    
+    private func openLinearityPaywallLink(url: URL) {
+        linearityPaywallLinkURL = url
+        showingWebPaywallLinkAlert = true
     }
 
     private func openWebPaywallLink(url: URL, method: PaywallComponent.ButtonComponent.URLMethod) {

--- a/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Button/ButtonComponentView.swift
@@ -202,7 +202,15 @@ struct ButtonComponentView: View {
     }
     
     private func openLinearityPaywallLink(url: URL) {
-        linearityPaywallLinkURL = url
+        if let email = Purchases.shared.attribution.getEmail()?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+           var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            var items = components.queryItems ?? []
+            items.append(.init(name: "prefilled_email", value: email))
+            components.queryItems = items
+            linearityPaywallLinkURL = components.url ?? url
+        } else {
+            linearityPaywallLinkURL = url
+        }
         showingWebPaywallLinkAlert = true
     }
 

--- a/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Packages/Package/PackageComponentView.swift
@@ -61,6 +61,9 @@ struct PackageComponentView: View {
                     variableContext: packageContext.variableContext)
                 )
             }
+#if targetEnvironment(macCatalyst)
+            .buttonStyle(.plain)
+#endif
         } else {
             EmptyView()
         }

--- a/RevenueCatUI/Templates/V2/Components/Tabs/TabControlButtonComponentView.swift
+++ b/RevenueCatUI/Templates/V2/Components/Tabs/TabControlButtonComponentView.swift
@@ -57,6 +57,9 @@ struct TabControlButtonComponentView: View {
             )
             .environment(\.componentViewState, self.selectedState)
         }
+#if targetEnvironment(macCatalyst)
+        .buttonStyle(.plain)
+#endif
 
     }
 

--- a/RevenueCatUI/Views/AsyncButton.swift
+++ b/RevenueCatUI/Views/AsyncButton.swift
@@ -47,6 +47,9 @@ struct AsyncButton<Label>: View where Label: View {
             self.label
         }
         .displayError(self.$error)
+#if targetEnvironment(macCatalyst)
+        .buttonStyle(.plain)
+#endif
     }
 
 }

--- a/Sources/Purchasing/Purchases/Attribution.swift
+++ b/Sources/Purchasing/Purchases/Attribution.swift
@@ -121,6 +121,13 @@ public extension Attribution {
     @objc func setEmail(_ email: String?) {
         self.subscriberAttributesManager.setEmail(email, appUserID: appUserID)
     }
+    
+    @objc func getEmail() -> String? {
+        self.subscriberAttributesManager.currentValueForAttribute(
+            key: ReservedSubscriberAttribute.email.key,
+            appUserID: appUserID
+        )
+    }
 
     /**
      * Subscriber attribute associated with the phone number for the user.

--- a/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
+++ b/Sources/SubscriberAttributes/SubscriberAttributesManager.swift
@@ -260,7 +260,7 @@ extension SubscriberAttributesManager: AttributeSyncing {
 
 }
 
-private extension SubscriberAttributesManager {
+extension SubscriberAttributesManager {
 
     func storeAttributeLocallyIfNeeded(key: String, value: String?, appUserID: String) {
         let currentValue = currentValueForAttribute(key: key, appUserID: appUserID)


### PR DESCRIPTION
Not a lot to see here.

I fixed the buttons on mac like I said on Slack. 

In the second commit I reused the existing RC web paywalls mechanism to show the warning popup for normal links. It's not localized but it will only be available in the US so it's fine.

In the last commit I added some stuff to be able to inject the user's email. Once we switch to web paywalls we will be able to remove that.