### PR TITLE
Filter out OfferingError code 1, underlyingError code 2

### DIFF
--- a/Sources/Purchasing/OfferingsManager.swift
+++ b/Sources/Purchasing/OfferingsManager.swift
@@ -642,6 +642,11 @@ func sendError(
     title: String,
     userInfo _userInfo: [String: AnyHashable],
 ) {
+    guard !shouldSuppressErrorNotification(error: error, underlyingError: underlyingError) else {
+        linearityLog("Suppressed error notification.\nError: '\(error)'.\nUnderlying error: '\(underlyingError, default: "<nil>")'")
+        return
+    }
+
     var userInfo = _userInfo
     
     userInfo["error.title"] = title
@@ -673,6 +678,17 @@ func sendError(
         let notification = Notification(name: OfferingsErrorNotification, object: nil, userInfo: userInfo)
         NotificationCenter.default.post(notification)
     }
+}
+
+func shouldSuppressErrorNotification(
+    error: Error,
+    underlyingError: Error?
+) -> Bool {
+    let nsError = (underlyingError ?? error) as NSError
+    // We are getting a lot of OfferingsErrors reported with the underlying error code indicating a store problem.
+    // These errors happen very often and we cannot do anything about them.
+    // So we filter them out to save our Bugsnag quota, which has run out lots of times because of this error.
+    return nsError.code == ErrorCode.storeProblemError.rawValue
 }
 
 func linearityLog(_ message: String) {


### PR DESCRIPTION
Here I'm filtering out errors with underlyingError.code == 2, aka `storeProblemError`.
This addresses our "Out of Quota" occurrences on Bugsnag due to many error reports like [these](https://app.bugsnag.com/linearity-gmbh/curve-macos/errors/69a847988d346d37516371f1?filters%5Berror.status%5D=for_review&filters%5Bevent.since%5D=30d&filters%5Bapp.release_stage%5D=release&sort=events).
<img width="1090" height="815" alt="image" src="https://github.com/user-attachments/assets/c91ec06b-ae88-4572-b50a-dacafac3c210" />
